### PR TITLE
Removes vendored awslabs config rules

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 3.0.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/main.tf
+++ b/main.tf
@@ -35,11 +35,6 @@ resource "aws_config_config_rule" "this" {
   ]
 }
 
-module "vendor" {
-  count  = local.custom_lambda ? 1 : 0
-  source = "git::https://github.com/plus3it/aws-config-rules.git?ref=e6fe305462333b26b55b30fc8586c4cf6f853907"
-}
-
 module "custom_lambda" {
   count  = local.custom_lambda ? 1 : 0
   source = "git::https://github.com/plus3it/terraform-aws-lambda.git?ref=v1.2.0"

--- a/tests/create_custom_config_rule/main.tf
+++ b/tests/create_custom_config_rule/main.tf
@@ -48,11 +48,15 @@ module "create_config_rules" {
     name                           = "config_rule_iam_access_key_rotation_check"
     policy                         = data.aws_iam_policy_document.lambda_iam_access_key_rotation_check.json
     runtime                        = "nodejs10.x"
-    source_path                    = "${path.module}/.terraform/modules/create_config_rules.vendor/node/iam_access_key_rotation-triggered.js"
+    source_path                    = "${path.module}/.terraform/modules/vendor/node/iam_access_key_rotation-triggered.js"
     reserved_concurrent_executions = -1
     tags                           = {}
     timeout                        = 15
   }
+}
+
+module "vendor" {
+  source = "git::https://github.com/plus3it/aws-config-rules.git?ref=e6fe305462333b26b55b30fc8586c4cf6f853907"
 }
 
 module "config" {

--- a/tests/create_legacy_config_rules/main.tf
+++ b/tests/create_legacy_config_rules/main.tf
@@ -15,6 +15,10 @@ module "create_config_rules" {
   lambda             = try(local.lambdas[each.key], null)
 }
 
+module "vendor" {
+  source = "git::https://github.com/plus3it/aws-config-rules.git?ref=e6fe305462333b26b55b30fc8586c4cf6f853907"
+}
+
 module "config" {
   source = "git::https://github.com/plus3it/terraform-aws-tardigrade-config.git?ref=1.0.7"
 
@@ -314,7 +318,7 @@ locals {
     })
   }
 
-  source_path = "${path.module}/.terraform/modules/create_config_rules.vendor"
+  source_path = "${path.module}/.terraform/modules/vendor"
 
   defaults = {
     config_rule = {


### PR DESCRIPTION
Module allows creation of any custom config rule. User can vendor
the awslabs config rules if they plan to use them. The tests are
examples of how to do that.